### PR TITLE
ChuGUI v0.1.2

### DIFF
--- a/packages/ChuGUI/0.1.2/ChuGUI.json
+++ b/packages/ChuGUI/0.1.2/ChuGUI.json
@@ -1,0 +1,19 @@
+{
+    "arch": "all",
+    "files": [
+        {
+            "checksum": "a5fab6f970ae05e3d1597c832f6518d9e3e9961c91797519a39f57c89130cb6d",
+            "file_type": "zip",
+            "local_dir": "./",
+            "url": "https://ccrma.stanford.edu/~hoangben/ChuGUI/releases/0.1.2/ChuGUI.zip"
+        }
+    ],
+    "language_version_min": {
+        "major": 5,
+        "mega": 1,
+        "minor": 5,
+        "patch": 0
+    },
+    "os": "any",
+    "version": "0.1.2"
+}

--- a/packages/ChuGUI/0.1.2/ChuGUI.json
+++ b/packages/ChuGUI/0.1.2/ChuGUI.json
@@ -2,7 +2,7 @@
     "arch": "all",
     "files": [
         {
-            "checksum": "a5fab6f970ae05e3d1597c832f6518d9e3e9961c91797519a39f57c89130cb6d",
+            "checksum": "23599e454add08a3463d07a342255dcd2b94f422ba129400c8a5134420657cf2",
             "file_type": "zip",
             "local_dir": "./",
             "url": "https://ccrma.stanford.edu/~hoangben/ChuGUI/releases/0.1.2/ChuGUI.zip"


### PR DESCRIPTION
v0.1.2 (November 2025)
=======
(added) Spinner component.
(added) Support for icon transparency and sampler options:

- UIStyle.VAR_ICON_TRANSPARENT -- options are true/1 or false/0
- UIStyle.VAR_ICON_SAMPLER -- options are UIStyle.NEAREST or UIStyle.LINEAR

(fixed) Fixed rare modulo-by-zero error that appears when fps drops.
(fixed) When disabled, buttons used to still be clickable.
(fixed) Fixed asset paths for the Checkbox component and examples.
(fixed) Made default styling more consistent.
(removed) Removed UIStyle.COL_COLOR_PICKER_LABEL -- use UIStyle.COL_LABEL instead