### PR TITLE
ChuGUI v0.2.0 and DMX v0.2.0

### DIFF
--- a/packages/ChuGUI/0.2.0/ChuGUI.json
+++ b/packages/ChuGUI/0.2.0/ChuGUI.json
@@ -1,0 +1,19 @@
+{
+    "arch": "all",
+    "files": [
+        {
+            "checksum": "dea99bf566ce4a4ee70e2d43376f9c641f1b8df3bc27e62e7cf44286cd9c5777",
+            "file_type": "zip",
+            "local_dir": "./",
+            "url": "https://ccrma.stanford.edu/~hoangben/ChuGUI/releases/0.2.0/ChuGUI.zip"
+        }
+    ],
+    "language_version_min": {
+        "major": 5,
+        "mega": 1,
+        "minor": 5,
+        "patch": 0
+    },
+    "os": "any",
+    "version": "0.2.0"
+}

--- a/packages/ChuGUI/0.2.0/ChuGUI.json
+++ b/packages/ChuGUI/0.2.0/ChuGUI.json
@@ -2,7 +2,7 @@
     "arch": "all",
     "files": [
         {
-            "checksum": "dea99bf566ce4a4ee70e2d43376f9c641f1b8df3bc27e62e7cf44286cd9c5777",
+            "checksum": "de4bdb65e82be0b8b26e0195ca6cf00d4d07fd3c94a9a70743a5811722ed5cbb",
             "file_type": "zip",
             "local_dir": "./",
             "url": "https://ccrma.stanford.edu/~hoangben/ChuGUI/releases/0.2.0/ChuGUI.zip"

--- a/packages/DMX/0.2.0/DMX_linux.json
+++ b/packages/DMX/0.2.0/DMX_linux.json
@@ -1,0 +1,19 @@
+{
+    "arch": "x86_64",
+    "files": [
+        {
+            "checksum": "ffd0364cfd5dd6e11a1e87bc2d9bfde881ce6711c6ba7fb01856bbd946d4ae96",
+            "file_type": "zip",
+            "local_dir": "./",
+            "url": "https://ccrma.stanford.edu/~hoangben/ChucK-DMX/releases/0.2.0/DMX_linux.zip"
+        }
+    ],
+    "language_version_min": {
+        "major": 5,
+        "mega": 1,
+        "minor": 5,
+        "patch": 0
+    },
+    "os": "linux",
+    "version": "0.2.0"
+}

--- a/packages/DMX/0.2.0/DMX_mac.json
+++ b/packages/DMX/0.2.0/DMX_mac.json
@@ -1,0 +1,19 @@
+{
+    "arch": "universal",
+    "files": [
+        {
+            "checksum": "f78ff9d6e92e4880f054ec23e229933b3c5978d18e8bbb335bd4493adc18a611",
+            "file_type": "zip",
+            "local_dir": "./",
+            "url": "https://ccrma.stanford.edu/~hoangben/ChucK-DMX/releases/0.2.0/DMX_mac.zip"
+        }
+    ],
+    "language_version_min": {
+        "major": 5,
+        "mega": 1,
+        "minor": 5,
+        "patch": 0
+    },
+    "os": "mac",
+    "version": "0.2.0"
+}

--- a/packages/DMX/0.2.0/DMX_win.json
+++ b/packages/DMX/0.2.0/DMX_win.json
@@ -1,0 +1,19 @@
+{
+    "arch": "x86_64",
+    "files": [
+        {
+            "checksum": "987217c463c103642590af3f89fdce7a9b25cb85482cf5149e7f1f3715f954ee",
+            "file_type": "zip",
+            "local_dir": "./",
+            "url": "https://ccrma.stanford.edu/~hoangben/ChucK-DMX/releases/0.2.0/DMX_win.zip"
+        }
+    ],
+    "language_version_min": {
+        "major": 5,
+        "mega": 1,
+        "minor": 5,
+        "patch": 0
+    },
+    "os": "windows",
+    "version": "0.2.0"
+}


### PR DESCRIPTION
ChuGUI v0.2.0 (February 2026)
=======
(added) Tooltip component:
 - ChuGUI.tooltip(string text) -- show a tooltip on hover for the last rendered component
 - Configurable hover delay (default 0.5s), positioned below the component
 - Configurable position via UIStyle.VAR_TOOLTIP_POSITION: UIStyle.TOP, UIStyle.BOTTOM, UIStyle.LEFT, UIStyle.RIGHT (default BOTTOM)
 - Styleable via UIStyle: COL_TOOLTIP, COL_TOOLTIP_TEXT, COL_TOOLTIP_BORDER
 - Style variables: VAR_TOOLTIP_TEXT_SIZE, VAR_TOOLTIP_PADDING, VAR_TOOLTIP_DELAY, VAR_TOOLTIP_GAP, VAR_TOOLTIP_Z_INDEX, VAR_TOOLTIP_BORDER_RADIUS, VAR_TOOLTIP_BORDER_WIDTH, VAR_TOOLTIP_FONT, VAR_TOOLTIP_POSITION
(added) Scenegraph debug view:
 - ChuGUI.debugScenegraph() -- renders a separate ImGUI window listing all active components with their properties (position, z-index, rotation, hover state, type-specific values)
 - Components sorted by z-index with ascending/descending toggle
 - Flat component list (no internal pool/map grouping exposed)
 - Position units displayed in header
(added) Auto-layout containers for vertical and horizontal stacking:
 - ChuGUI.beginColumn(vec2 pos) / ChuGUI.endColumn() -- vertical stack
 - ChuGUI.beginRow(vec2 pos) / ChuGUI.endRow() -- horizontal stack
 - Containers can be nested (e.g. a row inside a column)
 - UIStyle.VAR_CONTAINER_SPACING -- spacing between children
 - UIStyle.VAR_CONTAINER_PADDING -- inner padding
 - UIStyle.VAR_CONTAINER_CONTROL_POINTS -- control points for container positioning (row default: @(0, 0.5) vertically centered, column default: @(0, 1) top-aligned)
(added) SCREEN coordinate system (pixel-based, origin top-left, Y-down):
 - ChuGUI.SCREEN -- new unit constant for screen-pixel coordinates
 - ChuGUI.units(ChuGUI.SCREEN), ChuGUI.sizeUnits(ChuGUI.SCREEN), ChuGUI.posUnits(ChuGUI.SCREEN)
(added) Debug panel position editing:
 - Position override controls (enable/disable checkbox, world-space X/Y drag, min/max range)
 - Position overrides applied after user's pos() call, before applyLayout()
(added) Gamma correction control:
 - ChuGUI.gammaCorrection(int) -- enable/disable OutputPass gamma correction
 - ChuGUI.gammaCorrection() -- query current gamma correction state
(added) Support for icon blend modes:
 - UIStyle.VAR_ICON_BLEND_MODE -- options are Material.BLEND_MODE_ALPHA (0), BLEND_MODE_REPLACE (1), BLEND_MODE_ADD (2), BLEND_MODE_SUBTRACT (3), BLEND_MODE_MULTIPLY (4), BLEND_MODE_SCREEN (5)
(added) Global style variables that apply to all components (overridable by component-specific settings):
 - UIStyle.VAR_Z_INDEX -- sets z-index for all components
 - UIStyle.VAR_ROTATE -- sets rotation for all components
 - UIStyle.VAR_CONTROL_POINTS -- sets control points for all components
 - UIStyle.VAR_BORDER_RADIUS -- sets border radius for all components
 - UIStyle.VAR_BORDER_WIDTH -- sets border width for all components
 - UIStyle.VAR_FONT -- sets font for all components
 - UIStyle.VAR_SCALE -- sets scale for all components
(added) Per-component scale multiplier:
 - UIStyle.VAR_SCALE -- global float, uniform scale multiplier for all components (default 1.0)
 - Per-component overrides: VAR_RECT_SCALE, VAR_ICON_SCALE, VAR_LABEL_SCALE, VAR_BUTTON_SCALE, VAR_SLIDER_SCALE, VAR_CHECKBOX_SCALE, VAR_INPUT_SCALE, VAR_DROPDOWN_SCALE, VAR_KNOB_SCALE, VAR_METER_SCALE, VAR_RADIO_SCALE, VAR_SPINNER_SCALE, VAR_COLOR_PICKER_SCALE, VAR_SEPARATOR_SCALE
 - Multiplies all size-related values in a component; per-component falls back to VAR_SCALE
(added) Spritesheet/texture atlas support for Icon:
 - UIStyle.VAR_ICON_UV_OFFSET -- vec2, UV offset into the texture (default @(0, 0))
 - UIStyle.VAR_ICON_UV_SCALE -- vec2, UV region size (default @(1, 1) = full texture)
(added) New style variables for previously hardcoded values:
 - UIStyle.VAR_BUTTON_ICON_SPACING -- icon-text spacing factor (default 0.2)
 - UIStyle.VAR_INPUT_TEXT_PADDING -- text left padding (default 0.05)
 - UIStyle.VAR_INPUT_CHAR_WIDTH_RATIO -- character width ratio for cursor positioning (default 0.6)
 - UIStyle.VAR_INPUT_KEY_REPEAT_DELAY -- frames before key repeat starts (default 20)
 - UIStyle.VAR_INPUT_KEY_REPEAT_RATE -- frames between key repeats (default 5)
 - UIStyle.VAR_KNOB_INDICATOR_RADIUS -- indicator position factor (default 0.35)
 - UIStyle.VAR_COLOR_PICKER_PREVIEW_RATIO -- preview/slider width split ratio (default 0.3)
(added) Slider click-on-track:
 - Clicking anywhere on the slider track now jumps the handle to that position
 - Works for both Slider and DiscreteSlider
(added) DiscreteKnob component:
 - ChuGUI.discreteKnob(id, pos, min, max, steps, val) -- knob with discrete step snapping
 - Visual tick marks around the knob perimeter at each step position
 - Styleable: COL_KNOB_TICK, VAR_KNOB_TICK_SIZE, VAR_KNOB_TICK_RADIUS
 - Tick colors follow hover/pressed/disabled states
(added) Separator component:
 - ChuGUI.separator(vec2 pos) / ChuGUI.separator() -- thin horizontal divider line
 - Styleable: COL_SEPARATOR, COL_SEPARATOR_BORDER, VAR_SEPARATOR_SIZE, VAR_SEPARATOR_BORDER_RADIUS, VAR_SEPARATOR_BORDER_WIDTH
(added) Spacer utility:
 - ChuGUI.spacer(float size) -- advances container cursor without rendering anything
(added) Examples for new components:
 - knob/basic.ck updated with discrete knob alongside continuous knob
 - knob/style.ck updated with styled discrete knobs (tick colors, tick size, tick radius)
 - separator/basic.ck demonstrates separators in columns, spacers in rows, standalone separator
 - slider/basic.ck updated with click-on-track instruction label
(improved) Debug panel slider ranges are now user-adjustable with inline min/max controls.
(changed) Simplified debug API:
 - ChuGUI.debugEnabled() removed -- debug mode is now automatically enabled when ChuGUI.debug() is called
 - ChuGUI.debugScenegraph() no longer requires debug mode to be enabled -- just call it each frame
(fixed) Dropdown: clicking outside now closes the dropdown.
(fixed) Radio component was incorrectly referencing Checkbox style constants for z-index and rotation.
(fixed) Icon component preserves aspect ratio/size when size is not explicitly set.
(removed) Removed unused all_icons asset folder to reduce package size.

DMX v0.2.0 (February 2026)
=======
(BREAKING) removed rate(). send() no longer rate-limits internally.
(added) fade(ch, target, durationMs) for smooth channel transitions;
    call send() periodically (e.g., every 23ms) to animate fades
(added) fade(universe, ch, target, durationMs) to fade on a specific
    universe without switching the active universe
(added) channels(startCh, values[]) for batch-setting consecutive channels
(added) channel(ch) getter returning the current value (0-255)
(added) channel(universe, ch, value) to set a channel on a specific
    universe without switching the active universe
(added) connected() to check if the protocol is initialized and ready
(added) DMX.ports() static method to list available serial ports
(added) priority(p) getter/setter for sACN priority (0-200, default 100);
    can be changed live after init
(added) blackout() to zero all channels and cancel all fades
(added) static protocol constants: DMX.SERIAL_RAW, DMX.SERIAL, DMX.SACN,
    DMX.ARTNET
(added) multi-universe support: addUniverse(uni), removeUniverse(uni),
    universeCount(), and universes()
(added) universe() setter auto-creates universe data on first use
(added) name(string) getter/setter for sACN source name and ArtNet node
    name (default: 'ChucK DMX')
(added) debug(enable) to print channel values to stderr on each send()
(updated) init() returns 1 on success, 0 on failure
(updated) channel values clamped to 0-255 with a warning
(updated) setters return their value for ChucK chaining
    (e.g., DMX.SACN => dmx.protocol)
(updated) send() transmits all configured universes for sACN/ArtNet;
    Serial sends only the active universe
(fixed) various race conditions and threading issues
(fixed) ArtNet universe mapping (universe 1 now correctly maps to
    ArtNet address 0:0:0)
(fixed) Windows serial timing for DMX break signal
(fixed) sACN receivers losing connection between sends
(fixed) multiple DMX instances could interfere with each other's sACN
    initialization